### PR TITLE
Add rule documentation links feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the "freelint" extension will be documented in this file.
 
+## [0.0.6] - 2025-04-17
+
+### Added
+- Added rule documentation links in error messages - clicking on rule IDs now opens the relevant documentation
+- Created utility module for generating ESLint rule documentation URLs
+- Support for documentation links for core ESLint, React, React Hooks, and Import plugin rules
+
 ## [0.0.5] - 2023-05-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ FreeLint provides ESLint functionality without requiring local installation of E
 - Status bar indicator to toggle linting on/off
 - Set the React version for React linting rules
 - Includes test file generators to demonstrate linting capabilities
+- **NEW**: Clickable rule IDs in error messages that link to documentation
 
 ## Commands
 
@@ -30,6 +31,16 @@ This extension contributes the following settings:
 
 - `freelint.enabledPlugins`: Array of ESLint plugins to enable
 - `freelint.reactVersion`: React version to use for ESLint React rules
+
+## Documentation Links
+
+FreeLint now provides clickable rule IDs in error messages. When you hover over a linting error or warning, you'll see the rule ID (e.g., `no-unused-vars` or `react/jsx-key`). Clicking on this rule ID will open the relevant documentation in your browser, helping you understand the rule and how to fix the issue.
+
+Documentation links are supported for:
+- Core ESLint rules
+- React plugin rules
+- React Hooks plugin rules
+- Import/Export plugin rules
 
 ## Configuration
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "freelint",
   "displayName": "Freelint",
   "description": "ESLint functionality without requiring local installation",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "publisher": "Zach Tatman",
   "engines": {
     "vscode": "^1.80.0"

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 
 import { logger } from "./logger";
+import { getRuleDocumentationUrl } from "./ruleDocumentation";
 
 interface ESLintFix {
   range: [number, number];
@@ -272,6 +273,16 @@ export class Linter {
 
             if (message.ruleId) {
               diagnostic.source = `freelint(${message.ruleId})`;
+              
+              // Add rule documentation URL to the diagnostic message if available
+              const docUrl = getRuleDocumentationUrl(message.ruleId);
+              if (docUrl) {
+                // Use the code property to store the documentation URL
+                diagnostic.code = {
+                  value: message.ruleId,
+                  target: vscode.Uri.parse(docUrl)
+                };
+              }
             }
 
             if (message.severity === 2) {

--- a/src/ruleDocumentation.ts
+++ b/src/ruleDocumentation.ts
@@ -1,0 +1,61 @@
+/**
+ * This module provides utilities for generating documentation links for ESLint rules.
+ */
+
+/**
+ * Base URLs for documentation of different ESLint plugins
+ */
+const DOCUMENTATION_BASE_URLS: Record<string, string> = {
+  // Core ESLint rules
+  'eslint': 'https://eslint.org/docs/rules/',
+  
+  // React plugin rules
+  'react': 'https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/',
+  
+  // React Hooks plugin rules
+  'react-hooks': 'https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/README.md#',
+  
+  // Import plugin rules
+  'import': 'https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/',
+};
+
+/**
+ * Special cases for rules that don't follow the standard documentation pattern
+ */
+const SPECIAL_CASE_URLS: Record<string, string> = {
+  // React Hooks rules have a different URL pattern
+  'react-hooks/rules-of-hooks': 'https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/README.md#rules-of-hooks',
+  'react-hooks/exhaustive-deps': 'https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/README.md#exhaustive-deps',
+};
+
+/**
+ * Generate a documentation URL for an ESLint rule
+ * 
+ * @param ruleId The ESLint rule ID (e.g., 'no-unused-vars' or 'react/jsx-key')
+ * @returns A URL to the rule's documentation, or undefined if no documentation URL can be generated
+ */
+export function getRuleDocumentationUrl(ruleId: string | null): string | undefined {
+  if (!ruleId) {
+    return undefined;
+  }
+  
+  // Check if this is a special case rule with a custom URL
+  if (SPECIAL_CASE_URLS[ruleId]) {
+    return SPECIAL_CASE_URLS[ruleId];
+  }
+  
+  // Handle plugin rules (format: 'plugin-name/rule-name')
+  if (ruleId.includes('/')) {
+    const [pluginName, ruleName] = ruleId.split('/');
+    
+    // Check if we have a base URL for this plugin
+    if (DOCUMENTATION_BASE_URLS[pluginName]) {
+      return `${DOCUMENTATION_BASE_URLS[pluginName]}${ruleName}.md`;
+    }
+  } else {
+    // Handle core ESLint rules
+    return `${DOCUMENTATION_BASE_URLS.eslint}${ruleId}`;
+  }
+  
+  return undefined;
+}

--- a/src/ruleDocumentation.ts
+++ b/src/ruleDocumentation.ts
@@ -5,7 +5,7 @@
 /**
  * Base URLs for documentation of different ESLint plugins
  */
-const DOCUMENTATION_BASE_URLS: Record<string, string> = {
+const DOCUMENTATION_BASE_URLS: Record<string, string> = Object.freeze({
   // Core ESLint rules
   'eslint': 'https://eslint.org/docs/rules/',
   
@@ -17,16 +17,16 @@ const DOCUMENTATION_BASE_URLS: Record<string, string> = {
   
   // Import plugin rules
   'import': 'https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/',
-};
+});
 
 /**
  * Special cases for rules that don't follow the standard documentation pattern
  */
-const SPECIAL_CASE_URLS: Record<string, string> = {
+const SPECIAL_CASE_URLS: Record<string, string> = Object.freeze({
   // React Hooks rules have a different URL pattern
   'react-hooks/rules-of-hooks': 'https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/README.md#rules-of-hooks',
   'react-hooks/exhaustive-deps': 'https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/README.md#exhaustive-deps',
-};
+});
 
 /**
  * Generate a documentation URL for an ESLint rule


### PR DESCRIPTION
# Rule Documentation Links Feature

## Changes
- Added clickable rule IDs in error messages that link to relevant documentation
- Created a utility module for generating ESLint rule documentation URLs
- Support for documentation links for core ESLint, React, React Hooks, and Import plugin rules

## Testing
- Tested with various rule violations to ensure links work correctly
- Links open in the browser and point to the correct documentation pages

## Version
- Bumped version from 0.0.5 to 0.0.6
- Updated CHANGELOG.md and README.md with feature details