### PR TITLE
Chore/add prettier

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,11 +2,7 @@
   "root": true,
   "parser": "@babel/eslint-parser",
   "plugins": ["react", "prettier"],
-  "extends": [
-    "eslint:recommended", 
-    "plugin:react/recommended",
-    "prettier"
-  ],
+  "extends": ["eslint:recommended", "plugin:react/recommended", "prettier"],
   "env": {
     "node": true,
     "browser": true,
@@ -22,9 +18,12 @@
     "requireConfigFile": false,
     "babelOptions": {
       "presets": [
-        ["@babel/preset-react", {
-          "runtime": "automatic"
-        }]
+        [
+          "@babel/preset-react",
+          {
+            "runtime": "automatic"
+          }
+        ]
       ]
     }
   },

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,15 +1,20 @@
 {
   "root": true,
   "parser": "@babel/eslint-parser",
-  "plugins": ["react"],
-  "extends": ["eslint:recommended", "plugin:react/recommended"],
+  "plugins": ["react", "prettier"],
+  "extends": [
+    "eslint:recommended", 
+    "plugin:react/recommended",
+    "prettier"
+  ],
   "env": {
     "node": true,
     "browser": true,
     "es2022": true
   },
   "rules": {
-    "react/react-in-jsx-scope": "off"
+    "react/react-in-jsx-scope": "off",
+    "prettier/prettier": "error"
   },
   "parserOptions": {
     "ecmaVersion": "latest",

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,16 @@
+# Build artifacts
+dist/
+out/
+node_modules/
+
+# Coverage reports
+coverage/
+
+# Logs
+*.log
+
+# VS Code specific files
+.vscode/
+
+# Other generated files
+*.min.js

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,14 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "quoteProps": "as-needed",
+  "jsxSingleQuote": false,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "bracketSameLine": false,
+  "arrowParens": "avoid",
+  "endOfLine": "lf"
+}

--- a/FORMATTING.md
+++ b/FORMATTING.md
@@ -1,0 +1,63 @@
+# Code Formatting with Prettier
+
+This project uses [Prettier](https://prettier.io/) for code formatting to ensure consistent style across the codebase.
+
+## Setup
+
+The project is already configured with:
+- Prettier for code formatting
+- ESLint integration with Prettier
+- NPM scripts for formatting
+
+## VS Code Configuration
+
+To get the best experience with VS Code, configure your editor with these settings:
+
+1. Install the [Prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) for VS Code
+2. Configure VS Code to use Prettier as the default formatter and format on save:
+
+```json
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  "prettier.requireConfig": true
+}
+```
+
+You can add these settings to your user settings or workspace settings.
+
+## Available Scripts
+
+The following npm scripts are available for formatting:
+
+- `npm run format` - Format all TypeScript/JavaScript files using Prettier
+- `npm run format:check` - Check if files are formatted according to Prettier rules
+- `npm run lint:fix` - Run ESLint with automatic fixes
+
+## Prettier Configuration
+
+The Prettier configuration is defined in `.prettierrc` with the following settings:
+
+```json
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "quoteProps": "as-needed",
+  "jsxSingleQuote": false,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "bracketSameLine": false,
+  "arrowParens": "avoid",
+  "endOfLine": "lf"
+}
+```
+
+## Pre-commit Hooks (Future Enhancement)
+
+In the future, we may add pre-commit hooks using Husky and lint-staged to automatically format code before committing.

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,9 +1,9 @@
 module.exports = {
   presets: [
     [
-      "@babel/preset-react",
+      '@babel/preset-react',
       {
-        runtime: "automatic",
+        runtime: 'automatic',
       },
     ],
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freelint",
-  "version": "0.0.3",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freelint",
-      "version": "0.0.3",
+      "version": "0.0.6",
       "dependencies": {
         "@babel/core": "^7.23.9",
         "@babel/eslint-parser": "^7.23.9",
@@ -19,10 +19,14 @@
         "esquery": "^1.6.0"
       },
       "devDependencies": {
+        "@types/minimatch": "^5.1.2",
         "@types/node": "^20.11.19",
         "@types/vscode": "^1.80.0",
         "@vscode/test-electron": "^2.3.9",
+        "eslint-config-prettier": "^10.1.2",
+        "eslint-plugin-prettier": "^5.2.6",
         "path-browserify": "^1.0.1",
+        "prettier": "^3.5.3",
         "ts-loader": "^9.5.1",
         "typescript": "^5.0.0",
         "webpack": "^5.88.2",
@@ -724,6 +728,18 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@pkgr/core": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.4.tgz",
+      "integrity": "sha512-ROFF39F6ZrnzSUEmQQZUar0Jt4xVoP9WnDRdWwF4NNcXs3xBTLgBUDoOwW141y1jP+S8nahIbdxbFC7IShw9Iw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -765,6 +781,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
+    },
+    "node_modules/@types/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "20.17.28",
@@ -2019,6 +2041,18 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.2.tgz",
+      "integrity": "sha512-Epgp/EofAUeEpIdZkW60MHKvPyru1ruQJxPL+WIycnaPApuseK0Zpkrh/FwL9oIpQvIhJwV7ptOy0DWUjTlCiA==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
@@ -2129,6 +2163,36 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.6.tgz",
+      "integrity": "sha512-mUcf7QG2Tjk7H055Jk0lGBjbgDnfrvqjhXh9t2xLMSCjZVcw9Rb1V6sVNXO0th3jgeO7zllWPTNRil3JW94TnQ==",
+      "dev": true,
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.11.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-plugin-react": {
@@ -2330,6 +2394,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "dev": true
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -3998,6 +4068,33 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -4783,6 +4880,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/synckit": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.4.tgz",
+      "integrity": "sha512-Q/XQKRaJiLiFIBNN+mndW7S/RHxvwzuZS6ZwmRzUBqJBv/5QIKCEwkBC8GBf8EQJKYnaFs0wOZbKTXBPj8L9oQ==",
+      "dev": true,
+      "dependencies": {
+        "@pkgr/core": "^0.2.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -4914,6 +5027,12 @@
       "bin": {
         "json5": "lib/cli.js"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -114,8 +114,8 @@
     "pretest": "npm run compile-tests && npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
     "lint:fix": "eslint src --ext ts --fix",
-    "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json}\"",
-    "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json}\"",
+    "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json}\" \"**/*.json\" \"*.js\" \"*.config.js\"",
+    "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json}\" \"**/*.json\" \"*.js\" \"*.config.js\"",
     "test": "node ./out/test/runTest.js"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,11 @@
           "markdownDescription": "Select which ESLint plugins to enable.",
           "items": {
             "type": "string",
-            "enum": ["react", "react-hooks", "import"],
+            "enum": [
+              "react",
+              "react-hooks",
+              "import"
+            ],
             "enumDescriptions": [
               "React plugin for JSX and React-specific rules (enabled by default)",
               "React Hooks plugin for hooks-specific rules (enabled by default)",
@@ -68,7 +72,11 @@
             ]
           },
           "uniqueItems": true,
-          "default": ["react", "react-hooks", "import"]
+          "default": [
+            "react",
+            "react-hooks",
+            "import"
+          ]
         },
         "freelint.reactVersion": {
           "type": "string",
@@ -105,6 +113,9 @@
     "watch-tests": "tsc -p . --outDir out --watch",
     "pretest": "npm run compile-tests && npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
+    "lint:fix": "eslint src --ext ts --fix",
+    "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json}\"",
+    "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json}\"",
     "test": "node ./out/test/runTest.js"
   },
   "dependencies": {
@@ -123,7 +134,10 @@
     "@types/node": "^20.11.19",
     "@types/vscode": "^1.80.0",
     "@vscode/test-electron": "^2.3.9",
+    "eslint-config-prettier": "^10.1.2",
+    "eslint-plugin-prettier": "^5.2.6",
     "path-browserify": "^1.0.1",
+    "prettier": "^3.5.3",
     "ts-loader": "^9.5.1",
     "typescript": "^5.0.0",
     "webpack": "^5.88.2",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
-import * as vscode from "vscode";
-import { Linter, createLinter } from "./linter";
-import { logger } from "./logger";
-import { TestCommands, createTestCommands } from "./testCommands";
+import * as vscode from 'vscode';
+import { Linter, createLinter } from './linter';
+import { logger } from './logger';
+import { TestCommands, createTestCommands } from './testCommands';
 
 let linter: Linter;
 let testCommands: TestCommands;
@@ -25,11 +25,11 @@ export function activate(context: vscode.ExtensionContext) {
     // Initialize test commands
     testCommands = createTestCommands(linter);
 
-    window.showInformationMessage("Freelint Extension Activated!");
+    window.showInformationMessage('Freelint Extension Activated!');
 
     // Lint the active editor if it's a JavaScript/JSX/TypeScript file
     if (window.activeTextEditor) {
-      linter.lintDocument(window.activeTextEditor.document).catch((err) => {
+      linter.lintDocument(window.activeTextEditor.document).catch(err => {
         logger.error(`Error linting active document: ${err}`, true);
       });
     }
@@ -37,63 +37,60 @@ export function activate(context: vscode.ExtensionContext) {
     // Lint all visible editors
     if (window.visibleTextEditors.length > 0) {
       for (const editor of window.visibleTextEditors) {
-        linter.lintDocument(editor.document).catch((err) => {
+        linter.lintDocument(editor.document).catch(err => {
           logger.error(`Error linting visible documents: ${err}`, true);
         });
       }
     }
 
     // Register the manual lint command
-    const lintCommand = registerCommand("freelint.lintFile", async () => {
+    const lintCommand = registerCommand('freelint.lintFile', async () => {
       const editor = window.activeTextEditor;
       if (!editor) {
-        logger.error("No active editor", true);
-        window.showErrorMessage("No active editor");
+        logger.error('No active editor', true);
+        window.showErrorMessage('No active editor');
         return;
       }
       await linter.lintDocument(editor.document);
     });
 
     // Register a debug command to manually trigger logging
-    const debugCommand = registerCommand("freelint.debugLog", async () => {
+    const debugCommand = registerCommand('freelint.debugLog', async () => {
       const editor = window.activeTextEditor;
       if (!editor) {
-        logger.error("No active editor", true);
-        window.showErrorMessage("No active editor");
+        logger.error('No active editor', true);
+        window.showErrorMessage('No active editor');
         return;
       }
       await linter.lintDocument(editor.document);
       logger.logDiagnosticsSummary(
-          editor.document.uri,
-          linter.getDiagnosticCollection(),
-          linter.getEslintVersion()
+        editor.document.uri,
+        linter.getDiagnosticCollection(),
+        linter.getEslintVersion()
       );
     });
 
     // Register a command to create and open a test file
-    const createReactTestCommand = registerCommand(
-      "freelint.createReactTestFile",
-      async () => {
-        // Create a temp file
-        const workspaceFolder = workspace.workspaceFolders?.[0];
-        if (!workspaceFolder) {
-          logger.error("No workspace folder open", true);
-          window.showErrorMessage("No workspace folder open");
-          return;
-        }
-
-        await testCommands.createReactTestFile(workspaceFolder);
+    const createReactTestCommand = registerCommand('freelint.createReactTestFile', async () => {
+      // Create a temp file
+      const workspaceFolder = workspace.workspaceFolders?.[0];
+      if (!workspaceFolder) {
+        logger.error('No workspace folder open', true);
+        window.showErrorMessage('No workspace folder open');
+        return;
       }
-    );
+
+      await testCommands.createReactTestFile(workspaceFolder);
+    });
 
     const createImportExportTestCommand = registerCommand(
-      "freelint.createImportExportTestFile",
+      'freelint.createImportExportTestFile',
       async () => {
         // Create a temp file
         const workspaceFolder = workspace.workspaceFolders?.[0];
         if (!workspaceFolder) {
-          logger.error("No workspace folder open", true);
-          window.showErrorMessage("No workspace folder open");
+          logger.error('No workspace folder open', true);
+          window.showErrorMessage('No workspace folder open');
           return;
         }
         await testCommands.createImportExportTestFile(workspaceFolder);
@@ -101,30 +98,30 @@ export function activate(context: vscode.ExtensionContext) {
     );
 
     // Register a command to toggle FreeLint on/off
-    const toggleCommand = registerCommand("freelint.toggle", async () => {
+    const toggleCommand = registerCommand('freelint.toggle', async () => {
       const isEnabled = linter.toggle();
       updateStatusBar(isEnabled);
       if (isEnabled) {
-        logger.info("FreeLint enabled");
-        window.showInformationMessage("FreeLint enabled");
+        logger.info('FreeLint enabled');
+        window.showInformationMessage('FreeLint enabled');
 
         // Re-lint the active document
         if (window.activeTextEditor) {
           await linter.lintDocument(window.activeTextEditor.document);
         }
       } else {
-        logger.info("FreeLint disabled - diagnostics cleared");
-        window.showInformationMessage("FreeLint disabled");
+        logger.info('FreeLint disabled - diagnostics cleared');
+        window.showInformationMessage('FreeLint disabled');
       }
     });
 
     const createJavaScriptTestCommand = registerCommand(
-      "freelint.createJavaScriptTestFile",
+      'freelint.createJavaScriptTestFile',
       async () => {
         const workspaceFolder = workspace.workspaceFolders?.[0];
         if (!workspaceFolder) {
-          logger.error("No workspace folder open", true);
-          window.showErrorMessage("No workspace folder open");
+          logger.error('No workspace folder open', true);
+          window.showErrorMessage('No workspace folder open');
           return;
         }
         await testCommands.createJavaScriptTestFile(workspaceFolder);
@@ -132,71 +129,64 @@ export function activate(context: vscode.ExtensionContext) {
     );
 
     // Sets up automatic linting on file save
-    const saveListener = workspace.onDidSaveTextDocument(async (document) => {
+    const saveListener = workspace.onDidSaveTextDocument(async document => {
       if (!document.fileName.includes('extension-output')) {
         await linter.lintDocument(document);
       }
     });
 
     // Lint files when they are opened
-    const openListener = workspace.onDidOpenTextDocument(async (document) => {
+    const openListener = workspace.onDidOpenTextDocument(async document => {
       if (!document.fileName.includes('extension-output')) {
         await linter.lintDocument(document);
       }
     });
 
     // Also lint when an editor becomes active
-    const activeEditorListener = window.onDidChangeActiveTextEditor(
-      async (editor) => {
-        if (editor && !editor.document.fileName.includes('extension-output')) {
+    const activeEditorListener = window.onDidChangeActiveTextEditor(async editor => {
+      if (editor && !editor.document.fileName.includes('extension-output')) {
+        await linter.lintDocument(editor.document);
+      }
+    });
+
+    // Register a command to set React version
+    const setReactVersionCommand = registerCommand('freelint.setReactVersion', async () => {
+      // Provide common React versions as options
+      const reactVersions = [
+        '18.2.0', // Current stable
+        '18.0.0', // React 18 initial
+        '17.0.2', // React 17 latest
+        '16.14.0', // React 16 latest
+        '16.8.0', // First with hooks
+      ];
+
+      // Get current setting
+      const currentVersion = workspace.getConfiguration('freelint').get('reactVersion', '18.2.0');
+
+      // Show picker with current version highlighted
+      const selectedVersion = await window.showQuickPick(reactVersions, {
+        placeHolder: `Select React version for linting (current: ${currentVersion})`,
+      });
+
+      if (selectedVersion) {
+        // Update the setting
+        await workspace
+          .getConfiguration('freelint')
+          .update('reactVersion', selectedVersion, vscode.ConfigurationTarget.Global);
+
+        // Show confirmation
+        window.showInformationMessage(`React version set to ${selectedVersion}.`);
+
+        // Reload linter with new settings
+        linter = createLinter(context.extensionPath);
+
+        // Re-lint the active document
+        const editor = window.activeTextEditor;
+        if (editor) {
           await linter.lintDocument(editor.document);
         }
       }
-    );
-
-    // Register a command to set React version
-    const setReactVersionCommand = registerCommand(
-      "freelint.setReactVersion",
-      async () => {
-        // Provide common React versions as options
-        const reactVersions = [
-          "18.2.0", // Current stable
-          "18.0.0", // React 18 initial
-          "17.0.2", // React 17 latest
-          "16.14.0", // React 16 latest
-          "16.8.0"  // First with hooks
-        ];
-        
-        // Get current setting
-        const currentVersion = workspace.getConfiguration("freelint").get("reactVersion", "18.2.0");
-        
-        // Show picker with current version highlighted
-        const selectedVersion = await window.showQuickPick(reactVersions, {
-          placeHolder: `Select React version for linting (current: ${currentVersion})`,
-        });
-        
-        if (selectedVersion) {
-          // Update the setting
-          await workspace.getConfiguration("freelint").update(
-            "reactVersion",
-            selectedVersion,
-            vscode.ConfigurationTarget.Global
-          );
-          
-          // Show confirmation
-          window.showInformationMessage(`React version set to ${selectedVersion}.`);
-          
-          // Reload linter with new settings
-          linter = createLinter(context.extensionPath);
-          
-          // Re-lint the active document
-          const editor = window.activeTextEditor;
-          if (editor) {
-            await linter.lintDocument(editor.document);
-          }
-        }
-      }
-    );
+    });
 
     // Add subscriptions
     context.subscriptions.push(
@@ -214,11 +204,8 @@ export function activate(context: vscode.ExtensionContext) {
     );
 
     // Create and initialize status bar item
-    statusBarItem = window.createStatusBarItem(
-      vscode.StatusBarAlignment.Right,
-      100
-    );
-    statusBarItem.command = "freelint.toggle";
+    statusBarItem = window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
+    statusBarItem.command = 'freelint.toggle';
     updateStatusBar(true); // Initial state is enabled
     statusBarItem.show();
   } catch (error) {
@@ -233,10 +220,10 @@ export function activate(context: vscode.ExtensionContext) {
  * from outside this file.
  */
 function updateStatusBar(enabled: boolean): void {
-  statusBarItem.text = enabled ? "$(check) FreeLint" : "$(x) FreeLint";
+  statusBarItem.text = enabled ? '$(check) FreeLint' : '$(x) FreeLint';
   statusBarItem.tooltip = enabled
-    ? "FreeLint enabled - Click to disable"
-    : "FreeLint disabled - Click to enable";
+    ? 'FreeLint enabled - Click to disable'
+    : 'FreeLint disabled - Click to enable';
 }
 
 /**

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -1,10 +1,10 @@
-import { ESLint } from "eslint";
-import minimatch from "minimatch";
-import * as path from "path";
-import * as vscode from "vscode";
+import { ESLint } from 'eslint';
+import minimatch from 'minimatch';
+import * as path from 'path';
+import * as vscode from 'vscode';
 
-import { logger } from "./logger";
-import { getRuleDocumentationUrl } from "./ruleDocumentation";
+import { logger } from './logger';
+import { getRuleDocumentationUrl } from './ruleDocumentation';
 
 interface ESLintFix {
   range: [number, number];
@@ -31,9 +31,9 @@ interface PluginExtendMap {
  * This helps dynamically enable/disable plugins based on user configuration
  */
 const pluginExtendMap: PluginExtendMap = {
-  "react": "plugin:react/recommended",
-  "react-hooks": "plugin:react-hooks/recommended",
-  "import": "plugin:import/recommended"
+  react: 'plugin:react/recommended',
+  'react-hooks': 'plugin:react-hooks/recommended',
+  import: 'plugin:import/recommended',
 };
 
 /**
@@ -46,9 +46,9 @@ export class Linter {
   #debounceTimer: NodeJS.Timeout | undefined;
   #diagnosticCollection: vscode.DiagnosticCollection;
   #enabled: boolean = true;
-  #eslint!: ESLint;  // Using definite assignment assertion
+  #eslint!: ESLint; // Using definite assignment assertion
   #extensionPath: string;
-  #debounceDelay: number = 500;  // Default value
+  #debounceDelay: number = 500; // Default value
 
   constructor(extensionPath: string) {
     // Initialize the extension path
@@ -58,8 +58,7 @@ export class Linter {
     this.#initializeESLint();
 
     // Create diagnostic collection
-    this.#diagnosticCollection =
-      vscode.languages.createDiagnosticCollection("freelint");
+    this.#diagnosticCollection = vscode.languages.createDiagnosticCollection('freelint');
 
     // Register code action provider
     this.#codeActionProvider = vscode.languages.registerCodeActionsProvider(
@@ -67,10 +66,10 @@ export class Linter {
         { scheme: 'file', language: 'javascript' },
         { scheme: 'file', language: 'javascriptreact' },
         { scheme: 'file', language: 'typescript' },
-        { scheme: 'file', language: 'typescriptreact' }
+        { scheme: 'file', language: 'typescriptreact' },
       ],
       {
-        provideCodeActions: this.#provideCodeActions.bind(this)
+        provideCodeActions: this.#provideCodeActions.bind(this),
       }
     );
 
@@ -83,8 +82,10 @@ export class Linter {
 
     // Listen for configuration changes
     this.#configListener = vscode.workspace.onDidChangeConfiguration(event => {
-      if (event.affectsConfiguration('freelint.plugins') || 
-          event.affectsConfiguration('freelint.reactVersion')) {
+      if (
+        event.affectsConfiguration('freelint.plugins') ||
+        event.affectsConfiguration('freelint.reactVersion')
+      ) {
         // Clear existing diagnostics before reinitializing
         this.#diagnosticCollection.clear();
         this.#initializeESLint();
@@ -93,7 +94,7 @@ export class Linter {
         if (activeEditor) {
           this.lintDocument(activeEditor.document);
         }
-        vscode.window.showInformationMessage("FreeLint configuration updated - Rules reloaded");
+        vscode.window.showInformationMessage('FreeLint configuration updated - Rules reloaded');
       }
     });
   }
@@ -103,18 +104,20 @@ export class Linter {
    */
   #initializeESLint(): void {
     // Configuration settings
-    const config = vscode.workspace.getConfiguration("freelint");
-    this.#debounceDelay = config.get("debounceDelay", 500);
-    const reactVersion = config.get("reactVersion", "18.2.0");
-    const enabledPlugins = config.get<string[]>("plugins", ["react", "react-hooks", "import"]);
+    const config = vscode.workspace.getConfiguration('freelint');
+    this.#debounceDelay = config.get('debounceDelay', 500);
+    const reactVersion = config.get('reactVersion', '18.2.0');
+    const enabledPlugins = config.get<string[]>('plugins', ['react', 'react-hooks', 'import']);
 
     // Initialize ESLint with a basic configuration
     try {
       const baseConfig = {
         plugins: enabledPlugins,
         extends: [
-          "eslint:recommended",
-          ...enabledPlugins.flatMap(plugin => pluginExtendMap[plugin] ? [pluginExtendMap[plugin]] : []),
+          'eslint:recommended',
+          ...enabledPlugins.flatMap(plugin =>
+            pluginExtendMap[plugin] ? [pluginExtendMap[plugin]] : []
+          ),
         ],
         env: {
           browser: true,
@@ -123,48 +126,56 @@ export class Linter {
         },
         parserOptions: {
           ecmaVersion: 2021,
-          sourceType: "module",
+          sourceType: 'module',
           ecmaFeatures: {
             jsx: true,
           },
         },
         rules: {
           // eslint
-          "no-console": "warn",
-          "no-unused-vars": "warn",
-          "no-redeclare": "error",
-          "no-var": "warn",
-          "no-unreachable": "error",
-          "no-extra-semi": "warn",
-          "quotes": ["warn", "single"],
-          "eqeqeq": ["warn", "always"],
-          "semi": ["warn", "always"],
-          "no-undef": "error",
+          'no-console': 'warn',
+          'no-unused-vars': 'warn',
+          'no-redeclare': 'error',
+          'no-var': 'warn',
+          'no-unreachable': 'error',
+          'no-extra-semi': 'warn',
+          quotes: ['warn', 'single'],
+          eqeqeq: ['warn', 'always'],
+          semi: ['warn', 'always'],
+          'no-undef': 'error',
           // react rules - only include if react plugin is enabled
-          ...(enabledPlugins.includes("react") ? {
-            "react/react-in-jsx-scope": "off",
-            "react/jsx-pascal-case": "error",
-          } : {}),
+          ...(enabledPlugins.includes('react')
+            ? {
+                'react/react-in-jsx-scope': 'off',
+                'react/jsx-pascal-case': 'error',
+              }
+            : {}),
           // react-hooks rules - only include if react-hooks plugin is enabled
-          ...(enabledPlugins.includes("react-hooks") ? {
-            "react-hooks/rules-of-hooks": "error",
-            "react-hooks/exhaustive-deps": "warn",
-          } : {}),
+          ...(enabledPlugins.includes('react-hooks')
+            ? {
+                'react-hooks/rules-of-hooks': 'error',
+                'react-hooks/exhaustive-deps': 'warn',
+              }
+            : {}),
           // import rules - only include if import plugin is enabled
-          ...(enabledPlugins.includes("import") ? {
-            "import/no-unresolved": "error",
-            "import/named": "error",
-            "import/default": "error",
-            "import/namespace": "error",
-            "import/no-absolute-path": "error",
-          } : {}),
+          ...(enabledPlugins.includes('import')
+            ? {
+                'import/no-unresolved': 'error',
+                'import/named': 'error',
+                'import/default': 'error',
+                'import/namespace': 'error',
+                'import/no-absolute-path': 'error',
+              }
+            : {}),
         },
         settings: {
-          ...(enabledPlugins.includes("react") ? {
-            react: {
-              version: reactVersion,
-            },
-          } : {}),
+          ...(enabledPlugins.includes('react')
+            ? {
+                react: {
+                  version: reactVersion,
+                },
+              }
+            : {}),
         },
       };
 
@@ -174,7 +185,7 @@ export class Linter {
         baseConfig: baseConfig as any,
       } as ESLint.Options);
 
-      logger.info("ESLint instance successfully created");
+      logger.info('ESLint instance successfully created');
     } catch (err) {
       logger.error(`Failed to create ESLint instance: ${err}`, true);
       throw err;
@@ -201,21 +212,20 @@ export class Linter {
    */
   public async lintDocument(document: vscode.TextDocument): Promise<void> {
     try {
-      
       // Skip linting if disabled
       if (!this.#enabled) {
         return;
       }
 
       // Skip if the file extension is not valid
-      const validExtensions = [".js", ".jsx", ".ts", ".tsx"];
-      const fileExtension = path.extname(document.fileName);      
+      const validExtensions = ['.js', '.jsx', '.ts', '.tsx'];
+      const fileExtension = path.extname(document.fileName);
       if (!validExtensions.includes(fileExtension)) {
         return;
       }
 
       // Skip if the document's scheme is not file
-      if (document.uri.scheme !== "file") {
+      if (document.uri.scheme !== 'file') {
         return;
       }
 
@@ -225,8 +235,8 @@ export class Linter {
       }
 
       // Skip if the document matches any ignore patterns
-      const config = vscode.workspace.getConfiguration("freelint");
-      const ignorePatterns = config.get<string[]>("ignorePatterns", []);
+      const config = vscode.workspace.getConfiguration('freelint');
+      const ignorePatterns = config.get<string[]>('ignorePatterns', []);
       for (const pattern of ignorePatterns) {
         if (minimatch(document.fileName, pattern)) {
           logger.debug(`Skipping ${document.fileName} due to ignore pattern: ${pattern}`);
@@ -256,10 +266,10 @@ export class Linter {
             // Parameters: startLine, startColumn, endLine, endColumn (all 0-based)
             // ESLint reports positions as 1-based, so we subtract 1 to convert to VS Code's 0-based indexing
             const range = new vscode.Range(
-              message.line - 1,                                     // Start line (convert from 1-based to 0-based)
-              message.column - 1,                                   // Start column (convert from 1-based to 0-based)
-              message.endLine ? message.endLine - 1 : message.line - 1,  // End line (use endLine if available, otherwise use line)
-              message.endColumn ? message.endColumn - 1 : message.column - 1  // End column (use endColumn if available, otherwise use column)
+              message.line - 1, // Start line (convert from 1-based to 0-based)
+              message.column - 1, // Start column (convert from 1-based to 0-based)
+              message.endLine ? message.endLine - 1 : message.line - 1, // End line (use endLine if available, otherwise use line)
+              message.endColumn ? message.endColumn - 1 : message.column - 1 // End column (use endColumn if available, otherwise use column)
             );
 
             // Create a new diagnostic object with the range and message
@@ -273,14 +283,14 @@ export class Linter {
 
             if (message.ruleId) {
               diagnostic.source = `freelint(${message.ruleId})`;
-              
+
               // Add rule documentation URL to the diagnostic message if available
               const docUrl = getRuleDocumentationUrl(message.ruleId);
               if (docUrl) {
                 // Use the code property to store the documentation URL
                 diagnostic.code = {
                   value: message.ruleId,
-                  target: vscode.Uri.parse(docUrl)
+                  target: vscode.Uri.parse(docUrl),
                 };
               }
             }
@@ -304,9 +314,7 @@ export class Linter {
           }
         }
       } catch (eslintError) {
-        logger.error(
-          `ESLint error while linting ${document.fileName}: ${eslintError}`
-        );
+        logger.error(`ESLint error while linting ${document.fileName}: ${eslintError}`);
         vscode.window.showErrorMessage(`Linting failed: ${eslintError}`);
       }
     } catch (error) {
@@ -365,15 +373,11 @@ export class Linter {
    */
   async #getAutoFixResults(document: vscode.TextDocument) {
     const text = document.getText();
-    
+
     try {
       const baseConfig = {
-        plugins: ["react", "react-hooks", "import"],
-        extends: [
-          "eslint:recommended",
-          "plugin:react/recommended",
-          "plugin:import/recommended",
-        ],
+        plugins: ['react', 'react-hooks', 'import'],
+        extends: ['eslint:recommended', 'plugin:react/recommended', 'plugin:import/recommended'],
         env: {
           browser: true,
           es2021: true,
@@ -381,37 +385,37 @@ export class Linter {
         },
         parserOptions: {
           ecmaVersion: 2021,
-          sourceType: "module",
+          sourceType: 'module',
           ecmaFeatures: {
             jsx: true,
           },
         },
         rules: {
           // eslint
-          "react/react-in-jsx-scope": "off",
-          "no-console": "warn",
-          "no-unused-vars": "warn",
-          "no-redeclare": "error",
-          "no-var": "warn",
-          "no-unreachable": "error",
-          "no-extra-semi": "warn",
-          "quotes": ["warn", "single"],
-          "eqeqeq": ["warn", "always"],
-          "semi": ["warn", "always"],
-          "no-undef": "error",
+          'react/react-in-jsx-scope': 'off',
+          'no-console': 'warn',
+          'no-unused-vars': 'warn',
+          'no-redeclare': 'error',
+          'no-var': 'warn',
+          'no-unreachable': 'error',
+          'no-extra-semi': 'warn',
+          quotes: ['warn', 'single'],
+          eqeqeq: ['warn', 'always'],
+          semi: ['warn', 'always'],
+          'no-undef': 'error',
           // react
-          "react/jsx-pascal-case": "error",
-          "react-hooks/rules-of-hooks": "error",
-          "react-hooks/exhaustive-deps": "warn",
+          'react/jsx-pascal-case': 'error',
+          'react-hooks/rules-of-hooks': 'error',
+          'react-hooks/exhaustive-deps': 'warn',
           // import
-          "import/no-deprecated": "warn",
-          "import/cycle": "error",
-          "import/no-unresolved": "error",
-          "import/named": "error",
-          "import/default": "error",
-          "import/namespace": "error",
-          "import/no-absolute-path": "error",
-        }
+          'import/no-deprecated': 'warn',
+          'import/cycle': 'error',
+          'import/no-unresolved': 'error',
+          'import/named': 'error',
+          'import/default': 'error',
+          'import/namespace': 'error',
+          'import/no-absolute-path': 'error',
+        },
       };
 
       const fixESLint = new ESLint({
@@ -420,12 +424,12 @@ export class Linter {
         fix: true,
         baseConfig: baseConfig as any,
       } as ESLint.Options);
-      
+
       const results = await fixESLint.lintText(text, {
         filePath: document.uri.fsPath,
-        warnIgnored: true
+        warnIgnored: true,
       });
-      
+
       return results;
     } catch (error) {
       logger.error(`Error getting auto-fix results: ${error}`);
@@ -458,17 +462,17 @@ export class Linter {
         `Disable ${ruleId} for this line`,
         vscode.CodeActionKind.QuickFix
       );
-      
+
       const lineText = document.lineAt(diagnostic.range.start.line).text;
       const indentation = lineText.match(/^\s*/)?.[0] || '';
-      
+
       disableLineAction.edit = new vscode.WorkspaceEdit();
       disableLineAction.edit.insert(
         document.uri,
         new vscode.Position(diagnostic.range.start.line, 0),
         `${indentation}// eslint-disable-next-line ${ruleId}\n`
       );
-      
+
       actions.push(disableLineAction);
 
       // Add action to disable the rule for the entire file
@@ -476,14 +480,14 @@ export class Linter {
         `Disable ${ruleId} for entire file`,
         vscode.CodeActionKind.QuickFix
       );
-      
+
       disableFileAction.edit = new vscode.WorkspaceEdit();
       disableFileAction.edit.insert(
         document.uri,
         new vscode.Position(0, 0),
         `/* eslint-disable ${ruleId} */\n`
       );
-      
+
       actions.push(disableFileAction);
     }
 
@@ -496,48 +500,45 @@ export class Linter {
         const results = await this.#getAutoFixResults(document);
 
         const eslintResult = results[0];
-        
+
         // Check if there are any auto-fixable problems
         if (eslintResult?.output && eslintResult.output !== text) {
           // Add "Fix all auto-fixable problems" action
           const fixAllAction = new vscode.CodeAction(
-            "Fix all auto-fixable problems",
+            'Fix all auto-fixable problems',
             vscode.CodeActionKind.SourceFixAll
           );
-          
+
           fixAllAction.edit = new vscode.WorkspaceEdit();
           fixAllAction.edit.replace(
             document.uri,
-            new vscode.Range(
-              document.positionAt(0),
-              document.positionAt(text.length)
-            ),
+            new vscode.Range(document.positionAt(0), document.positionAt(text.length)),
             eslintResult.output
           );
-          
+
           actions.push(fixAllAction);
-          
+
           // Check for individual rule fixes and add them if possible
           for (const diagnostic of context.diagnostics) {
             if (!diagnostic.source?.startsWith('freelint')) {
               continue;
             }
-            
+
             const ruleId = diagnostic.source.match(/\((.*?)\)/)?.[1];
             if (!ruleId) continue;
-            
+
             // Find fixes specific to this rule and diagnostic range
             const fixes = eslintResult.messages
               .filter((msg: ESLintMessage) => msg.ruleId === ruleId && msg.fix)
               .map((msg: ESLintMessage) => msg.fix as ESLintFix);
-              
+
             if (fixes.length > 0) {
               const fixAction = new vscode.CodeAction(
                 `Fix ${ruleId} issue`,
                 vscode.CodeActionKind.QuickFix
               );
               fixAction.edit = new vscode.WorkspaceEdit();
-              
+
               // Apply all fixes for this rule
               for (const fix of fixes) {
                 if (fix) {
@@ -551,7 +552,7 @@ export class Linter {
                   );
                 }
               }
-              
+
               fixAction.diagnostics = [diagnostic];
               actions.push(fixAction);
             }
@@ -569,17 +570,17 @@ export class Linter {
   /**
    * Debounce the linting to avoid excessive updates
    */
-    #debounceLint(document: vscode.TextDocument): void {
-      if (this.#debounceTimer) {
-        clearTimeout(this.#debounceTimer);
-      }
+  #debounceLint(document: vscode.TextDocument): void {
+    if (this.#debounceTimer) {
+      clearTimeout(this.#debounceTimer);
+    }
 
     this.#debounceTimer = setTimeout(() => {
-      this.lintDocument(document).catch((err) => {
+      this.lintDocument(document).catch(err => {
         logger.error(`Error during debounced lint: ${err}`);
       });
     }, this.#debounceDelay);
-    }
+  }
 }
 
 // Export a function to create a new linter

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,4 @@
-import * as vscode from "vscode";
+import * as vscode from 'vscode';
 
 /**
  * Logger class to handle all output channel and debug logging functionality.
@@ -7,8 +7,8 @@ export class Logger {
   #outputChannel: vscode.OutputChannel;
 
   constructor() {
-    this.#outputChannel = vscode.window.createOutputChannel("FreeLint");
-    this.info("FreeLint extension activated");
+    this.#outputChannel = vscode.window.createOutputChannel('FreeLint');
+    this.info('FreeLint extension activated');
   }
 
   /**
@@ -48,11 +48,7 @@ export class Logger {
    * @param errorCount Number of errors found
    * @param warningCount Number of warnings found
    */
-  public logLintResults(
-    fileName: string,
-    errorCount: number,
-    warningCount: number
-  ): void {
+  public logLintResults(fileName: string, errorCount: number, warningCount: number): void {
     const message = `Linted ${fileName}: ${errorCount} errors, ${warningCount} warnings\n`;
     if (errorCount > 0 || warningCount > 0) {
       this.info(message);
@@ -73,23 +69,26 @@ export class Logger {
     eslintVersion: string
   ): void {
     // Show configuration information
-    this.info("--- FreeLint Configuration ---", true);
+    this.info('--- FreeLint Configuration ---', true);
     this.info(`ESLint version: ${eslintVersion}`, true);
-    
+
     // Get and log other configuration settings
-    const config = vscode.workspace.getConfiguration("freelint");
-    const reactVersion = config.get("reactVersion", "18.2.0");
-    const debounceDelay = config.get("debounceDelay", 500);
-    const ignorePatterns = config.get<string[]>("ignorePatterns", []);
-    const enabledPlugins = config.get<string[]>("plugins", ["react", "react-hooks", "import"]);
-    
+    const config = vscode.workspace.getConfiguration('freelint');
+    const reactVersion = config.get('reactVersion', '18.2.0');
+    const debounceDelay = config.get('debounceDelay', 500);
+    const ignorePatterns = config.get<string[]>('ignorePatterns', []);
+    const enabledPlugins = config.get<string[]>('plugins', ['react', 'react-hooks', 'import']);
+
     this.info(`React version: ${reactVersion}`, true);
     this.info(`Debounce delay: ${debounceDelay}ms`, true);
-    this.info(`Ignore patterns: ${ignorePatterns.length > 0 ? `[${ignorePatterns.join(", ")}]` : "none"}`, true);
-    this.info(`Enabled plugins: [${enabledPlugins.join(", ")}]\n`, true);
+    this.info(
+      `Ignore patterns: ${ignorePatterns.length > 0 ? `[${ignorePatterns.join(', ')}]` : 'none'}`,
+      true
+    );
+    this.info(`Enabled plugins: [${enabledPlugins.join(', ')}]\n`, true);
 
     // Show diagnostic information
-    this.info("--- FreeLint Diagnostics Summary ---", true);
+    this.info('--- FreeLint Diagnostics Summary ---', true);
 
     // Get our own diagnostics
     const freelintDiagnostics = diagnosticCollection.get(uri) || [];
@@ -98,7 +97,7 @@ export class Logger {
     // Group and log issues by rule with line numbers
     const ruleGroups: Record<string, vscode.Diagnostic[]> = {};
     for (const diag of freelintDiagnostics) {
-      const ruleName = diag.source || "unknown";
+      const ruleName = diag.source || 'unknown';
       if (!ruleGroups[ruleName]) {
         ruleGroups[ruleName] = [];
       }
@@ -135,7 +134,7 @@ export class Logger {
   #logOtherLinterIssues(uri: vscode.Uri): void {
     const allDiagnostics = vscode.languages.getDiagnostics(uri);
     const otherLinterDiagnostics = allDiagnostics.filter(d => !d.source?.startsWith('freelint'));
-    
+
     if (otherLinterDiagnostics.length > 0) {
       // Group diagnostics by source (linter name)
       const linterGroups: Record<string, vscode.Diagnostic[]> = {};

--- a/src/ruleDocumentation.ts
+++ b/src/ruleDocumentation.ts
@@ -7,16 +7,17 @@
  */
 const DOCUMENTATION_BASE_URLS: Record<string, string> = Object.freeze({
   // Core ESLint rules
-  'eslint': 'https://eslint.org/docs/rules/',
-  
+  eslint: 'https://eslint.org/docs/rules/',
+
   // React plugin rules
-  'react': 'https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/',
-  
+  react: 'https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/',
+
   // React Hooks plugin rules
-  'react-hooks': 'https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/README.md#',
-  
+  'react-hooks':
+    'https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/README.md#',
+
   // Import plugin rules
-  'import': 'https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/',
+  import: 'https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/',
 });
 
 /**
@@ -24,13 +25,15 @@ const DOCUMENTATION_BASE_URLS: Record<string, string> = Object.freeze({
  */
 const SPECIAL_CASE_URLS: Record<string, string> = Object.freeze({
   // React Hooks rules have a different URL pattern
-  'react-hooks/rules-of-hooks': 'https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/README.md#rules-of-hooks',
-  'react-hooks/exhaustive-deps': 'https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/README.md#exhaustive-deps',
+  'react-hooks/rules-of-hooks':
+    'https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/README.md#rules-of-hooks',
+  'react-hooks/exhaustive-deps':
+    'https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/README.md#exhaustive-deps',
 });
 
 /**
  * Generate a documentation URL for an ESLint rule
- * 
+ *
  * @param ruleId The ESLint rule ID (e.g., 'no-unused-vars' or 'react/jsx-key')
  * @returns A URL to the rule's documentation, or undefined if no documentation URL can be generated
  */
@@ -38,16 +41,16 @@ export function getRuleDocumentationUrl(ruleId: string | null): string | undefin
   if (!ruleId) {
     return undefined;
   }
-  
+
   // Check if this is a special case rule with a custom URL
   if (SPECIAL_CASE_URLS[ruleId]) {
     return SPECIAL_CASE_URLS[ruleId];
   }
-  
+
   // Handle plugin rules (format: 'plugin-name/rule-name')
   if (ruleId.includes('/')) {
     const [pluginName, ruleName] = ruleId.split('/');
-    
+
     // Check if we have a base URL for this plugin
     if (DOCUMENTATION_BASE_URLS[pluginName]) {
       return `${DOCUMENTATION_BASE_URLS[pluginName]}${ruleName}.md`;
@@ -56,6 +59,6 @@ export function getRuleDocumentationUrl(ruleId: string | null): string | undefin
     // Handle core ESLint rules
     return `${DOCUMENTATION_BASE_URLS.eslint}${ruleId}`;
   }
-  
+
   return undefined;
 }

--- a/src/testCommands.ts
+++ b/src/testCommands.ts
@@ -1,7 +1,7 @@
-import * as path from "path";
-import * as vscode from "vscode";
-import { Linter } from "./linter";
-import { logger } from "./logger";
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { Linter } from './linter';
+import { logger } from './logger';
 
 /**
  * Class to handle creation of test files for demonstrating linting capabilities.
@@ -17,13 +17,8 @@ export class TestCommands {
    * Create a react test file with various lint issues.
    * @param workspaceFolder The workspace folder to create the file in
    */
-  public async createReactTestFile(
-    workspaceFolder: vscode.WorkspaceFolder
-  ): Promise<void> {
-    const testFilePath = path.join(
-      workspaceFolder.uri.fsPath,
-      "test-react.jsx"
-    );
+  public async createReactTestFile(workspaceFolder: vscode.WorkspaceFolder): Promise<void> {
+    const testFilePath = path.join(workspaceFolder.uri.fsPath, 'test-react.jsx');
     const testContent = `
 import React, { useState, useEffect, useCallback } from 'react';
 
@@ -70,10 +65,7 @@ export default HooksComponent;
       const uri = vscode.Uri.file(testFilePath);
 
       // Write the test content to the file
-      await vscode.workspace.fs.writeFile(
-        uri,
-        Buffer.from(testContent, "utf8")
-      );
+      await vscode.workspace.fs.writeFile(uri, Buffer.from(testContent, 'utf8'));
 
       // Open the file
       const document = await vscode.workspace.openTextDocument(uri);
@@ -83,18 +75,13 @@ export default HooksComponent;
       await this.#linter.lintDocument(document);
 
       // Show a message in the output channel
-      logger.info(
-        `Created react test file: ${path.basename(testFilePath)}`,
-        true
-      );
+      logger.info(`Created react test file: ${path.basename(testFilePath)}`, true);
       vscode.window.showInformationMessage(
         "React test file created with lint issues. Check 'FreeLint' output for details."
       );
     } catch (error) {
       logger.error(`Error creating react test file: ${error}`);
-      vscode.window.showErrorMessage(
-        `Failed to create react test file: ${error}`
-      );
+      vscode.window.showErrorMessage(`Failed to create react test file: ${error}`);
     }
   }
 
@@ -102,19 +89,11 @@ export default HooksComponent;
    * Creates a test file with import/export errors to demonstrate eslint-plugin-import rules.
    * @param workspaceFolder The workspace folder to create the file in
    */
-  public async createImportExportTestFile(
-    workspaceFolder: vscode.WorkspaceFolder
-  ): Promise<void> {
-    const testFilePath = path.join(
-      workspaceFolder.uri.fsPath,
-      "import-export-test.js"
-    );
+  public async createImportExportTestFile(workspaceFolder: vscode.WorkspaceFolder): Promise<void> {
+    const testFilePath = path.join(workspaceFolder.uri.fsPath, 'import-export-test.js');
 
     // Create a supporting module file to make some of the errors more realistic
-    const supportingModulePath = path.join(
-      workspaceFolder.uri.fsPath,
-      "some-local-module.js"
-    );
+    const supportingModulePath = path.join(workspaceFolder.uri.fsPath, 'some-local-module.js');
 
     const supportingModuleContent = `
 // A supporting module with some exports
@@ -185,14 +164,11 @@ console.log('This file demonstrates various import/export errors');
       // Write the supporting module content to the file
       await vscode.workspace.fs.writeFile(
         supportingUri,
-        Buffer.from(supportingModuleContent, "utf8")
+        Buffer.from(supportingModuleContent, 'utf8')
       );
 
       // Write the test content to the file
-      await vscode.workspace.fs.writeFile(
-        uri,
-        Buffer.from(testContent, "utf8")
-      );
+      await vscode.workspace.fs.writeFile(uri, Buffer.from(testContent, 'utf8'));
 
       // Open the file
       const document = await vscode.workspace.openTextDocument(uri);
@@ -202,18 +178,13 @@ console.log('This file demonstrates various import/export errors');
       await this.#linter.lintDocument(document);
 
       // Show a message in the output channel
-      logger.info(
-        `Created import/export test file: ${path.basename(testFilePath)}`,
-        true
-      );
+      logger.info(`Created import/export test file: ${path.basename(testFilePath)}`, true);
       vscode.window.showInformationMessage(
         "Import/export test file created with lint issues. Check 'FreeLint' output for details."
       );
     } catch (error) {
       logger.error(`Error creating import/export test file: ${error}`);
-      vscode.window.showErrorMessage(
-        `Failed to create import/export test file: ${error}`
-      );
+      vscode.window.showErrorMessage(`Failed to create import/export test file: ${error}`);
     }
   }
 
@@ -221,13 +192,8 @@ console.log('This file demonstrates various import/export errors');
    * Create a JavaScript test file with various general ESLint errors.
    * @param workspaceFolder The workspace folder to create the file in
    */
-  public async createJavaScriptTestFile(
-    workspaceFolder: vscode.WorkspaceFolder
-  ): Promise<void> {
-    const testFilePath = path.join(
-      workspaceFolder.uri.fsPath,
-      "test-javascript.js"
-    );
+  public async createJavaScriptTestFile(workspaceFolder: vscode.WorkspaceFolder): Promise<void> {
+    const testFilePath = path.join(workspaceFolder.uri.fsPath, 'test-javascript.js');
     const testContent = `
 // Missing semicolons
 const missingTerminator = 5
@@ -298,10 +264,7 @@ if (true) {
       const uri = vscode.Uri.file(testFilePath);
 
       // Write the test content to the file
-      await vscode.workspace.fs.writeFile(
-        uri,
-        Buffer.from(testContent, "utf8")
-      );
+      await vscode.workspace.fs.writeFile(uri, Buffer.from(testContent, 'utf8'));
 
       // Open the file
       const document = await vscode.workspace.openTextDocument(uri);
@@ -311,18 +274,13 @@ if (true) {
       await this.#linter.lintDocument(document);
 
       // Show a message in the output channel
-      logger.info(
-        `Created JavaScript test file: ${path.basename(testFilePath)}`,
-        true
-      );
+      logger.info(`Created JavaScript test file: ${path.basename(testFilePath)}`, true);
       vscode.window.showInformationMessage(
         "JavaScript test file created with lint issues. Check 'FreeLint' output for details."
       );
     } catch (error) {
       logger.error(`Error creating JavaScript test file: ${error}`);
-      vscode.window.showErrorMessage(
-        `Failed to create JavaScript test file: ${error}`
-      );
+      vscode.window.showErrorMessage(`Failed to create JavaScript test file: ${error}`);
     }
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,29 +1,26 @@
-const path = require("path");
+const path = require('path');
 
 module.exports = {
-  target: "node",
-  mode: "none",
-  entry: "./src/extension.ts", // Your TypeScript entry file
+  target: 'node',
+  mode: 'none',
+  entry: './src/extension.ts', // Your TypeScript entry file
   output: {
-    path: path.resolve(__dirname, "dist"), // Output directory for bundled files
-    filename: "extension.js", // Output file
-    libraryTarget: "commonjs2", // Ensure CommonJS module format for VSCode
+    path: path.resolve(__dirname, 'dist'), // Output directory for bundled files
+    filename: 'extension.js', // Output file
+    libraryTarget: 'commonjs2', // Ensure CommonJS module format for VSCode
   },
   externals: {
-    vscode: "commonjs vscode", // Only keep vscode as external
+    vscode: 'commonjs vscode', // Only keep vscode as external
   },
   resolve: {
-    extensions: [".ts", ".js"], // Resolve TypeScript and JavaScript files
+    extensions: ['.ts', '.js'], // Resolve TypeScript and JavaScript files
     fallback: {
-      path: require.resolve("path-browserify"),
+      path: require.resolve('path-browserify'),
       fs: false,
     },
-    mainFields: ["main", "module"],
+    mainFields: ['main', 'module'],
     alias: {
-      "@babel/preset-react": path.resolve(
-        __dirname,
-        "node_modules/@babel/preset-react"
-      ),
+      '@babel/preset-react': path.resolve(__dirname, 'node_modules/@babel/preset-react'),
     },
   },
   module: {
@@ -32,11 +29,11 @@ module.exports = {
         test: /\.ts$/,
         use: [
           {
-            loader: "ts-loader",
+            loader: 'ts-loader',
           },
         ],
       },
     ],
   },
-  devtool: "nosources-source-map",
+  devtool: 'nosources-source-map',
 };


### PR DESCRIPTION
# Add Prettier for Code Formatting

## Overview
This PR adds Prettier to standardize code formatting across the project.

## Changes
- Added Prettier configuration (`.prettierrc`) with project-specific formatting rules
- Created `.prettierignore` to exclude certain files from formatting
- Integrated Prettier with ESLint via `eslint-config-prettier` and `eslint-plugin-prettier`
- Added npm scripts for formatting:
  - `npm run format` - Format all files
  - `npm run format:check` - Check formatting without making changes
  - `npm run lint:fix` - Run ESLint with automatic fixes
- Added documentation in `FORMATTING.md` with setup instructions
- Formatted all source files according to the new Prettier rules

## Benefits
- Consistent code style across the codebase
- Reduced code review friction by automating formatting decisions
- Better developer experience with clear formatting guidelines
- Improved code readability and maintainability

## Testing
- Verified formatting works with `npm run format`
- Confirmed formatting check works with `npm run format:check`
- Tested ESLint integration to ensure it respects Prettier rules

## Notes
- Developers should install the Prettier VS Code extension for the best experience
- See `FORMATTING.md` for detailed setup instructions